### PR TITLE
Feature: Coded product page

### DIFF
--- a/product.html
+++ b/product.html
@@ -5,12 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Product page</title>
     <link rel="stylesheet" href="/styles/main.css"/>
+    <link rel="stylesheet" href="/styles/product.css">
+    
 </head>
 <body>
     <main>
-        <p>
-            test
-        </p>
+        <section id="fetch-content">
+        </section>
     </main>
     <footer>
         <nav>
@@ -31,6 +32,7 @@
             </a>
         </nav>
     </footer>
+    <script src="/scripts/product.js"></script>
 </body>
 
 </html>

--- a/products.json
+++ b/products.json
@@ -18,7 +18,7 @@
         "salt": "0.16 g"
     }
 }, {
-    "id": "0",
+    "id": "0000000000002",
     "title": "Idun Tomatketchup Uten Tilsatt Sukker",
     "description": "Idun Tomatketchup Uten Tilsatt Sukker er en klassisk ketchup med en fyldig og god smak av tomat. Ketchupen er laget av solmodne tomater og er helt uten konserveringsmidler. Idun Tomatketchup Uten Tilsatt Sukker passer perfekt til pølser, hamburgere, pommes frites og annen fastfood.",
     "image": "https://bilder.kolonial.no/local_products/7a139224-262c-4ced-8f9f-3bc32a79e18c.jpg?auto=format&fit=max&w=326&s=7641b1bb8e5638dfab1f9471b91fe457",
@@ -37,7 +37,7 @@
         "salt": "1.60 g"
     }
 }, {
-    "id": "1",
+    "id": "0000000000003",
     "title": "Pizza Grandiosa",
     "description": "Pizza Grandiosa er en klassisk frossenpizza med skinke, kjøttdeig, paprika og champignon. Pizzabunnen er sprø og god og er toppet med en fyldig pizzasaus og et rikt fyll av kjøtt og grønnsaker. Pizza Grandiosa er en populær middag for både store og små og er enkel å tilberede i ovnen.",
     "image": "https://bilder.kolonial.no/local_products/3c687979-1d00-4e07-bab2-baa0e97f8c4d.jpg?auto=format&fit=max&w=999&s=75df93c66400e87b6a5f0cb92e0a28b2",
@@ -56,7 +56,7 @@
         "salt": "0.90 g"
     }
 }, {
-    "id": "2",
+    "id": "0000000000004",
     "title": "Tine Melk 1L",
     "description": "Tine Melk er en klassisk lettmelk med 1,0% fett. Melken er homogenisert og pasteurisert og har en frisk og god smak. Tine Melk passer perfekt til frokostblandinger, kaffe, te og kakao. Melken er også god å drikke som den er, eller som et mellommåltid.",
     "image": "https://bilder.kolonial.no/local_products/86888da8-561e-4ae2-a18d-7160762391c1.jpg?auto=format&fit=max&w=403&s=98d7a38ce9735ef76cb14c48bb91f6aa",
@@ -75,7 +75,7 @@
         "salt": "0.10 g"
     }
 }, {
-    "id": "3",
+    "id": "0000000000005",
     "title": "Tine Lettrømme",
     "description": "Tine Lettrømme er en frisk og syrlig rømme med 17% fett. Rømmen er laget av pasteurisert fløte og syrnet med melkesyrekultur. Tine Lettrømme passer perfekt til taco, bakt potet, fiskeretter og som tilbehør til supper og gryteretter.",
     "image": "https://bilder.kolonial.no/local_products/b34a2bbb-aebd-4def-aae9-46fbf521c21f.jpg?auto=format&fit=max&w=1000&s=fafb96715cec82c82f685a7af6d6ec75",
@@ -94,7 +94,7 @@
         "salt": "0.08 g"
     }
 }, {
-    "id": "4",
+    "id": "0000000000006",
     "title": "Safari Original",
     "description": "Safarikjeks fra Sætre 200 g nam nam kjeks er godt.",
     "image": "https://bilder.kolonial.no/local_products/872564c8-4a97-48cd-92bf-18133dcbcafc.jpg?auto=format&fit=max&w=1000&s=10cda4f9d877de16874e00ddfcf4a31d",
@@ -113,7 +113,7 @@
         "salt": "0.70 g"
     }
 }, {
-    "id": "5",
+    "id": "0000000000007",
     "title": "Santa Maria Taco Spice Mix",
     "description": "Taco Spice Mix fra Santa Maria",
     "image": "https://bilder.kolonial.no/local_products/9a750a74-17f0-40fb-8b5b-fe8e09cc15df.jpeg?auto=format&fit=max&w=293&s=4b45f1314efe631e5a5bb7b5b2825583",
@@ -132,7 +132,7 @@
         "salt": "15.70 g"
     }
 }, {
-    "id": "6",
+    "id": "0000000000008",
     "title": "Mutti Pizzasaus Klassisk",
     "description": "Denne klassiske pizzasausen har en god og fyldig tomatsmak. Sausen er uten krydder, slik at du kan tilsette de smakene du liker best.",
     "image": "https://bilder.kolonial.no/local_products/d95c65ca-1a74-4a5c-8442-a858164c1f08.jpeg?auto=format&fit=max&w=225&s=a96fcd92ce85f965aa068239acf96eab",
@@ -151,7 +151,7 @@
         "salt": "0.53 g"
     }
 }, {
-    "id": "7",
+    "id": "0000000000009",
     "title": "Extra Virgin Olivenolje",
     "description": "Extra Virgin Olivenolje fra Rema 1000.",
     "image": "https://bilder.kolonial.no/local_products/cec34750-214c-4506-a878-799fecd21b48.jpg?auto=format&fit=max&w=247&s=d030d8dd62d77cc909d86f3f77cb6591",
@@ -170,7 +170,7 @@
         "salt": "0 g"
     }
 }, {
-    "id": "8",
+    "id": "0000000000010",
     "title": "Fria Sjokoladekake",
     "description": "Glutenfri Kladdkake som passer perfekt både til hverdag of til fest!",
     "image": "https://bilder.kolonial.no/local_products/c78e158c-324d-4960-afc4-051881bdb42d.jpg?auto=format&fit=max&w=1000&s=f8a9459b03c6795e713ce77b8c66dbea",

--- a/scripts/product.js
+++ b/scripts/product.js
@@ -1,0 +1,44 @@
+const productContainer = document.getElementById("fetch-content");
+const ApiUrl = "https://raw.githubusercontent.com/JNettli/010-BarcodeAllergenScanner/main/products.json"
+const url = window.location.search;
+let eanId = url.slice(4,17) 
+console.log(eanId)
+
+function emphasizeAllergens() {
+    const allergensContainer = document.getElementById("allergens-container");
+    const allergenDivs = allergensContainer.querySelectorAll(".allergen");
+
+    allergenDivs.forEach(div => {
+        const allergenName = div.textContent.trim();
+        if (localStorage.getItem(allergenName) === "true") {
+            div.classList.add("emphasized");
+        }
+    });
+}
+
+function amendProduct(data) {
+    const product = data.find(item => item.id === eanId);
+    if (product) {
+        const productInfo = `
+            <h1>${product.title}</h1>
+            <img src="${product.image}" alt="${product.title}" id="product-image">
+            <p>Allergens:</p>
+            <div id="allergens-container">
+                ${product.allergens.map(allergen => `<div class="allergen">${allergen}</div>`).join('')}
+            </div>
+        `;
+        productContainer.innerHTML = productInfo;
+        emphasizeAllergens();
+
+    } else {
+        const titleElement = document.createElement('h2');
+        titleElement.textContent = "Product not found";
+        productContainer.appendChild(titleElement);
+    }
+}
+
+
+fetch(ApiUrl)
+    .then(response => response.json())
+    .then(data => amendProduct(data))
+    .catch(error => console.log(error));

--- a/styles/product.css
+++ b/styles/product.css
@@ -1,0 +1,10 @@
+#product-image{
+    width: 100px;
+    height: 100px;
+}
+
+
+.emphasized{
+    background-color: red;
+    color: white;
+}


### PR DESCRIPTION
Completed EAN product retrieval process.

**Product page coded with following features:** 
- EAN number submitted via the text input on [index.html](https://midnightfalcons.netlify.app/index.html) is added to the URL as a parameter. 
- URL Parameter is read to append the corresponding catalogue product from [products.json](https://github.com/JNettli/010-BarcodeAllergenScanner/blob/main/products.json) to the page, with image, title, allergens and potentially more data if required.
- A list is compiled of div containers for each corresponding allergen associated with the product. 
- The list is then cross referenced with the keys in local storage index. Duplicates are then highlighted with red to emphazise allergy

**Things to note:** 

- Product ID's have been temporarily altered for testing purposes - until proper EAN codes are associated. entries 2-10 now follow the naming convention 0000000000001 ++. This was done to buypass the [code validation](https://github.com/JNettli/010-BarcodeAllergenScanner/pull/47) on the [index](https://midnightfalcons.netlify.app/index.html) input field, as the ID's did not contain 13-digit EAN ID's, but were only called "2", "3" etc
- Styling... well... at least the page is working.🥹
- Some sort of exaggerated notice can be implemented for cases where a marked allergy is detected. (Popup, a warning, red background, sound, etc.)
- The page is directly based off the previous and hard-coded [allergy.html](https://midnightfalcons.netlify.app/allergy.html)-page, which for now is abandoned and should be removed.
- Some mechanism to prevent opening a blank product (a 13-digit ID not contained within our JSON) could be in order. Can be a "No product found" redirect-link to go back to the input or potentially a filter preventing sumbitting on the index page. 
- Page is not linked to the kassalapp-API at this point. 